### PR TITLE
Added assembly references

### DIFF
--- a/ppControl.ps1
+++ b/ppControl.ps1
@@ -1,3 +1,6 @@
+[void] [System.Reflection.Assembly]::LoadWithPartialName("System.Drawing") 
+[void] [System.Reflection.Assembly]::LoadWithPartialName("System.Windows.Forms") 
+
 Param(
     [Parameter(Mandatory=$false)] [Switch] $Install,
     [Parameter(Mandatory=$false)] [Switch] $AutoStart,


### PR DESCRIPTION
Without the references on some systems and error will show up:
`Cannot find type [System.Windows.Forms.MenuItem]`